### PR TITLE
Maak van fractie en dagelijksbestuur top-level elementen

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -23,6 +23,16 @@
                         <xs:documentation>Gegevens over een stemming. Een stemming heeft altijd betrekking op een bepaald agendapunt, maar het is daarnaast ook mogelijk om over personen te stemmen, zoals bij een benoeming van een raadslid. Iemands stemkeuze tijdens een bepaalde stemming hoort thuis onder `aanwezigeDeelnemer`.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                <xs:element name="fractie" type="fractieGegevens" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Gegevens over een fractie, zoals de fractienaam en stemmingen waaraan de fractie heeft deelgenomen.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="dagelijksBestuur" type="dagelijksBestuurGegevens" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>Gegevens over een dagelijks bestuur, zoals de naam van het bestuur.</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
                 <xs:element name="natuurlijkPersoon" type="natuurlijkPersoonGegevens" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>Gegevens met contextuele informatie over een persoon, zoals diens naam en fractielidmaatschap.</xs:documentation>
@@ -591,9 +601,9 @@
                     <xs:documentation>Datum waarop iemands lidmaatschap van het dagelijkse bestuur eindigde.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="dagelijksBestuur" type="dagelijksBestuurGegevens" minOccurs="1" maxOccurs="1">
+            <xs:element name="heeftBetrekkingOp" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over het dagelijks bestuur waar het lidmaatschap betrekking op heeft, zoals de naam van het bestuur.</xs:documentation>
+                    <xs:documentation>Verwijzing naar het dagelijks bestuur waar het lidmaatschap betrekking op heeft.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
@@ -785,9 +795,9 @@
                     <xs:documentation>Geeft aan of iemand fractievoorzitter is.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="fractie" type="fractieGegevens" minOccurs="1" maxOccurs="1">
+            <xs:element name="heeftBetrekkingOp" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over de fractie waar het lidmaatschap betrekking op heeft, zoals de fractienaam.</xs:documentation>
+                    <xs:documentation>Verwijzing naar de fractie waar het lidmaatschap betrekking op heeft.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>


### PR DESCRIPTION
`fractie`/`dagelijkstbestuur` kwam voorheen ergens onder `<personen>`; na deze PR worden het zelfstandige top-level elementen. 

Dit veranderd de regels omtrent nesting vs. verwijzen terug naar hoe die oorspronkelijk waren: koppel objecten middels een verwijzing als er of (1) meerdere inkomende pijltjes zijn, of (2) wanneer je logischerwijs meermaals naar hetzelfde object zou willen refereren.

Regel (2) gaat op voor fracties en dagelijks besturen: daar kunnen per definitie meerdere personen lid van zijn, en dus zou je er herhaaldelijk naar willen verwijzen.  

De aanpak in deze PR is een stuk mooier, imo. Fracties en dagelijks besturen worden na deze PR meer herbruikbaar, en het voelde altijd conceptueel onlogisch om fracties onder personen  neer te zetten (alsof fracties onderdeel zouden zijn van personen).   Bovendien beruste het feit dat deze hiërarchie aanwezig was op een soort miscommunicatie. 