### PR TITLE
Versoepel regels voor volgnummers

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -289,21 +289,21 @@
             </xs:element>
             <xs:element name="geplandAgendapuntVolgnummer" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Het geplande agendapunt volgnummer. Begint met een of meer cijfers, en wordt eventueel gevolgd door een reeks letters.</xs:documentation>
+                    <xs:documentation>Het geplande agendapunt volgnummer. Begint met een of meer cijfers, maar mag gevolgd worden door andere karakters.</xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:pattern value="\d+[A-Za-z]*"/>
+                        <xs:pattern value="\d+.*"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
             <xs:element name="agendapuntVolgnummer" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Het agendapunt volgnummer. Begint met een of meer cijfers, en wordt eventueel gevolgd door een reeks letters.</xs:documentation>
+                    <xs:documentation>Het agendapunt volgnummer. Begint met een of meer cijfers, maar mag gevolgd worden door andere karakters.</xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:string">
-                        <xs:pattern value="\d+[A-Za-z]*"/>
+                        <xs:pattern value="\d+.*"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>


### PR DESCRIPTION
In de praktijk doen mensen gekken dingen. Bovendien wordt een regex
 voor iets als `1.2.a` al snel complex en lastig te documenteren.

Op deze wijze blijft het wel nog mogelijk om numeriek op volgnummers te sorteren (tot op een zekere hoogte)