### PR TITLE
ci: speedup

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   xmllint:
+    runs-on: ubuntu-latest
     container:
       image: registry.gitlab.com/pipeline-components/xmllint:latest
 


### PR DESCRIPTION
Een docker met xmllint preinstalled lijkt sneller. 