### PR TITLE
Verander datatype van bestuurslaag-elementen naar `begripGegevens`

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -202,9 +202,9 @@
                     <xs:documentation>Datum en tijdstip waarop de vergadering voor het laatst gepubliceerd of gewijzigd is.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="bestuurslaag" type="bestuurslaagGegevens" minOccurs="0" maxOccurs="1">
+            <xs:element name="bestuurslaag" type="begripGegevens" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over de bestuurslaag die de vergadering heeft gehouden. Deze laag kan een gemeente, provincie of waterschap zijn.</xs:documentation>
+                    <xs:documentation>Gegevens over de bestuurslaag die de vergadering heeft gehouden. Deze gegevens komen doorgaans uit de TOOI waardenlijsten 'Register gemeenten compleet', 'Register provincies compleet' of 'Register waterschappen compleet'.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="isVastgelegdMiddels" type="informatieobjectGegevens" minOccurs="0" maxOccurs="unbounded">
@@ -306,9 +306,9 @@
                     <xs:documentation>Geeft aan of het agendapunt besloten werd behandeld.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="bestuurslaag" type="bestuurslaagGegevens" minOccurs="0" maxOccurs="1">
+            <xs:element name="bestuurslaag" type="begripGegevens" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over de bestuurslaag die het agendapunt heeft behandeld. Deze laag kan een gemeente, provincie of waterschap zijn.</xs:documentation>
+                    <xs:documentation>Gegevens over de bestuurslaag die het agendapunt heeft behandeld. Deze gegevens komen doorgaans uit de TOOI waardenlijsten 'Register gemeenten compleet', 'Register provincies compleet' of 'Register waterschappen compleet'.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="wordtBehandeldTijdens" type="verwijzingGegevens" minOccurs="0" maxOccurs="1">
@@ -535,9 +535,9 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:element>
-            <xs:element name="bestuurslaag" type="bestuurslaagGegevens" minOccurs="1" maxOccurs="1">
+            <xs:element name="bestuurslaag" type="begripGegevens" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over de bestuurslaag die verantwoordelijk is voor de taken van dit dagelijks bestuur. Deze laag kan een gemeente, provincie of waterschap zijn.</xs:documentation>
+                    <xs:documentation>Gegevens over de bestuurslaag die verantwoordelijk is voor de taken van dit dagelijks bestuur. Deze gegevens komen doorgaans uit de TOOI waardenlijsten 'Register gemeenten compleet', 'Register provincies compleet' of 'Register waterschappen compleet'.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
@@ -719,9 +719,9 @@
                     <xs:documentation>De naam van de fractie, zoals `D66` of `VVD`.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="bestuurslaag" type="bestuurslaagGegevens" minOccurs="0" maxOccurs="1">
+            <xs:element name="bestuurslaag" type="begripGegevens" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>De bestuurslaag waarop de fractie functioneert. Deze laag kan een gemeente, provincie of waterschap zijn.</xs:documentation>
+                    <xs:documentation>De bestuurslaag waarop de fractie functioneert. Deze gegevens komen doorgaans uit de TOOI waardenlijsten 'Register gemeenten compleet', 'Register provincies compleet' of 'Register waterschappen compleet'.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="fractieNeemtDeelAanStemming" type="stemresultaatPerFractieGegevens" minOccurs="0" maxOccurs="unbounded">
@@ -894,99 +894,5 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="gemeenteGegevens">
-        <xs:sequence>
-            <xs:element name="gemeentecode" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        De code van de gemeente uit de TOOI begrippenlijst 'Register gemeenten compleet'.
-                        Dit is een viercijferige code, eventueel voorafgegaan door het voorvoegsel 'gm',
-                        zoals `gm0518` voor de gemeente Den Haag. Voor de volledige lijst, 
-                        zie https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="(GM|gm)?\d{4}"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="gemeentenaam" type="xs:string" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>De naam van de gemeente.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="waterschapGegevens">
-        <xs:sequence>
-            <xs:element name="waterschapcode" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        De code van het waterschap uit de TOOI begrippenlijst 'Register waterschappen compleet'.
-                        Dit is een viercijferige code, eventueel voorafgegaan door het voorvoegsel 'ws', 
-                        zoals `ws0652` voor waterschap Brabantse Delta. Voor de volledige lijst, 
-                        zie https://identifier.overheid.nl/tooi/set/rwc_waterschappen_compleet/2
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="(ws|WS)?\d{4}"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="waterschapnaam" type="xs:string" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>De naam van het waterschap.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="provincieGegevens">
-        <xs:sequence>
-            <xs:element name="provinciecode" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        De code van de provincie uit de TOOI begrippenlijst 'Register provincies compleet'.
-                        Dit is een tweecijferige code, eventueel voorafgegaan door het voorvoegsel 'pv',
-                        zoals `pv20` voor de provincie Groningen. Voor de volledige lijst,
-                        zie https://identifier.overheid.nl/tooi/set/rwc_provincies_compleet/1
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="(pv|PV)?\d{2}"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="provincienaam" type="xs:string" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>De naam van de provincie.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="bestuurslaagGegevens">
-        <xs:annotation>
-            <xs:documentation>Geeft de relevante bestuurslaag aan, middels een keuze uit drie gegevensgroepen.</xs:documentation>
-        </xs:annotation>
-        <xs:choice>
-            <xs:element name="gemeente" type="gemeenteGegevens" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>Gegevens die een gemeente uniek identificeren.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="waterschap" type="waterschapGegevens" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>Gegevens die een waterschap uniek identificeren.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="provincie" type="provincieGegevens" minOccurs="1" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>Gegevens die een provincie uniek identificeren.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:choice>
     </xs:complexType>
 </xs:schema>

--- a/Voorbeelden/Voorbeeld.ori-a.xml
+++ b/Voorbeelden/Voorbeeld.ori-a.xml
@@ -13,10 +13,12 @@
         <eindeVergadering>2023-11-30T23:00:00</eindeVergadering>
         <publicatiedatum>2023-12-15T14:12:15</publicatiedatum>
         <bestuurslaag>
-            <gemeente>
-                <gemeentecode>gm0546</gemeentecode>
-                <gemeentenaam>Gemeente Leiden</gemeentenaam>
-            </gemeente>
+            <begripLabel>Gemeente Leiden</begripLabel>
+            <begripCode>gm0546</begripCode>
+            <verwijzingBegrippenlijst>
+                <verwijzingID>https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4</verwijzingID>
+                <verwijzingNaam>Register gemeenten compleet</verwijzingNaam>
+            </verwijzingBegrippenlijst>
         </bestuurslaag>
         <isVastgelegdMiddels>
             <informatieobjectType>
@@ -163,10 +165,12 @@
         <dagelijksBestuurNaam>College van B&amp;W</dagelijksBestuurNaam>
         <dagelijksBestuurType>College</dagelijksBestuurType>
         <bestuurslaag>
-            <gemeente>
-                <gemeentecode>gm0546</gemeentecode>
-                <gemeentenaam>Gemeente Leiden</gemeentenaam>
-            </gemeente>
+            <begripLabel>Gemeente Leiden</begripLabel>
+            <begripCode>gm0546</begripCode>
+            <verwijzingBegrippenlijst>
+                <verwijzingID>https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4</verwijzingID>
+                <verwijzingNaam>Register gemeenten compleet</verwijzingNaam>
+            </verwijzingBegrippenlijst>
         </bestuurslaag>
     </dagelijksBestuur>
 


### PR DESCRIPTION
Na deze pull request geef je aan bij welke bestuurslaag iets hoort middels een `begripGegevens`, ipv het choice mechanisme wat zelf geknutseld hadden.

Deze verandering maakt ORI-A XML stukken flexibeler (en ook rijksoverheid compatible), maar allicht minder goed leesbaar, minder strikt geüniformeerd, en foutgevoeliger. 

Voor hoe dit er uit ziet in XML vorm, verwijs ik je naar  de aanpassingen in de voorbeeldbestanden die onderdeel zijn van deze PR. 

(`begripGegevens` moet nog op veel meer plekken komen, maar dit is by far een van de meest ingrijpende, daarom een aparte PR).

----

Ik vraag me vooral af de `xs:documentation` beter kan, of uitgebreid moet worden. 