### PR TITLE
voorbeelden: voeg aanvullendeMetagegevens toe

### DIFF
--- a/Voorbeelden/MDTO/Videotuul_Gemeenteraad_30_november_2023.mdto.xml
+++ b/Voorbeelden/MDTO/Videotuul_Gemeenteraad_30_november_2023.mdto.xml
@@ -37,6 +37,13 @@
 				<identificatieBron>Parlaeus</identificatieBron>
 			</verwijzingIdentificatie>
 		</heeftRepresentatie>
+        <aanvullendeMetagegevens>
+            <verwijzingNaam>Voorbeeld.ori-a.xml</verwijzingNaam>
+            <verwijzingIdentificatie>
+                <identificatieKenmerk>20a280a8a8a88220008208822f6b6b02</identificatieKenmerk>
+                <identificatieBron>Parlaeus</identificatieBron>
+            </verwijzingIdentificatie>
+        </aanvullendeMetagegevens>
 		<archiefvormer>
 			<verwijzingNaam>Gemeente Leiden</verwijzingNaam>
 			<verwijzingIdentificatie>


### PR DESCRIPTION
@lmasrarsaml Is dit hoe we mensen  optie die we mensen moeten gaan geven, of zelfs aanraden, qua hoe ze hun MDTO data aan ORI-A XML kunnen koppelen? 

Ik heb nu in de MDTO XML van de videotuul `aanvullendeMetagegevens` toegevoegd. Maar misschien past het beter anders? 

Daarbinnen hebben we ook weer twee keuzes: of wenemen alleen `verwijzingNaam` mee (wat denk ik de naam van het desbetreffende ORI-A bestand moet zijn), of voegen ook nog `verwijzingIdentificatie` toe (wat ik nu heb gedaan). 

Ik weet niet of dit laatste conceptueel helemaal klopt, iig in haar huidige vorm. Het ID wat ik nu bij `verwijzingIdentificatie` heb toegevoegd is het ID van de vergadering. Maar eigenlijk zou een ID van het ORI-A bestand zelf toepasselijker zijn (of iig een globalere ID). 

Ik kan me op zich wel voorstellen dat een `verwijzingIdentificatie` handig is om ORI-A gegevens gegarandeerd uniek te kunnen identificeren.  