### PR TITLE
docs: documentatie direct onder elk complextype

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -5,12 +5,12 @@
             <xs:sequence>
                 <xs:element name="vergadering" type="vergaderingGegevens" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
-                        <xs:documentation>Gegevens over een vergadering, zoals de startdatum en locatie.</xs:documentation>
+                        <xs:documentation>Gegevens over de vergadering, zoals de startdatum en locatie.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="agendapunt" type="agendapuntGegevens" minOccurs="1" maxOccurs="unbounded">
                     <xs:annotation>
-                        <xs:documentation>Gegevens over een agendapunt, zoals het volgnummer en bijbehorende stukken. De volgorde van agendapunt-elementen geeft aan in welke volgorde ze behandeld zijn.</xs:documentation>
+                        <xs:documentation>Gegevens over een agendapunt, zoals het volgnummer en bijbehorende stukken. Bij het ontbreken van volgnummers, moet de volgorde van agendapunt-elementen aangeven in welke volgorde ze behandeld zijn.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="stemming" type="stemmingGegevens" minOccurs="0" maxOccurs="unbounded">
@@ -118,6 +118,9 @@
     <!-- # Domeinspecifieke datatypes -->
 
     <xs:complexType name="vergaderingGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een vergadering, zoals de startdatum en locatie.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
@@ -238,6 +241,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="agendapuntGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een agendapunt, zoals het volgnummer en bijbehorende stukken. Bij het ontbreken van volgnummers, moet de volgorde van agendapunt-elementen aangeven in welke volgorde ze behandeld zijn.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
@@ -342,6 +348,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="spreekfragmentGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een spreekfragment waarin een deelnemer sprak, zoals het moment waarop dit fragment begon en eindigde.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -411,6 +420,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="stemmingGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een stemming, zoals het agendapunt of de persoon waarover gestemd is. Iemands stemkeuze op een stemming hoort onder `aanwezigeDeelnemer`.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
@@ -470,6 +482,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="stemmingOverPersonenGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens die het het resultaat van een stemming over personen beschrijven, zoals het aantal stemmen wat een persoon haalde.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="naamKandidaat" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
@@ -484,6 +499,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="besluitGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een besluit waartoe een stemming heeft geleid, zoals of het unaniem aangenomen of verworpen is.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -518,6 +536,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="dagelijksBestuurGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een dagelijks bestuur, zoals de naam van het bestuur.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
@@ -549,6 +570,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="dagelijksBestuurLidmaatschapGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over wanneer iemand lid is geworden van een bepaald dagelijks bestuur.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -573,6 +597,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="natuurlijkPersoonGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een natuurlijk persoon. Dit datatype komt voor onder de top-level elementen `aanwezigeDeelnemer` en `persoonBuitenVergadering`.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
@@ -641,6 +668,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="naamGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over de naam van een persoon, zoals diens voor- en achternaam.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="achternaam" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
@@ -670,6 +700,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="nevenfunctieGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over de nevenfuncties van een persoon, zoals of het om een betaalde functie gaat.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="omschrijving" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
@@ -714,6 +747,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="fractieGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een fractie, zoals de naam en het stemgedrag van de fractie.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
@@ -738,6 +774,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="fractielidmaatschapGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over iemands fractielidmaatschap.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -767,6 +806,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="stemresultaatPerFractieGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over hoe een fractie als geheel tegenover een stemming stond, zoals of de aanwezigen leden unaniem voor, unaniem tegen, of juist verdeeld hebben gestemd.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -793,6 +835,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="aanwezigeDeelnemerGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een persoon die daadwerkelijk bij de vergadering aanwezig was, zoals diens stemgedrag, inspreek momenten, en meer algemene persoonsgegevens.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -847,6 +892,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="stemGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een stem die iemand heeft uitbracht, zoals diens stemkeuze en de stemming waarop deze keuze betrekking heeft.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="ID" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
@@ -874,6 +922,9 @@
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="gremiumGegevens">
+        <xs:annotation>
+            <xs:documentation>Gegevens over een gremium.</xs:documentation>
+        </xs:annotation>
         <xs:sequence>
             <xs:element name="gremiumIdentificatie" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>


### PR DESCRIPTION
Veel tooling, zoals de ORI-A website en python code generators, zien graag een beschrijving van complextypes bij de complextype zelf.

Een ding waar ik over twijfel is dat alle documentatie nu min of meer dubbel in de XSD komt:

```xml
    <!-- Vergadering onder het root element ORI-A -->
    <xs:element name="ORI-A">
        <xs:complexType>
            <xs:sequence>
                <xs:element name="vergadering" type="vergaderingGegevens" minOccurs="1" maxOccurs="1">
                    <xs:annotation>
                        <xs:documentation>Gegevens over de vergadering, zoals de startdatum en locatie.</xs:documentation>
                    </xs:annotation>
                </xs:element>

    <!-- complextype definitie -->
    <xs:complexType name="vergaderingGegevens">
        <xs:annotation>
            <xs:documentation>Gegevens over een vergadering, zoals de startdatum en locatie.</xs:documentation>
        </xs:annotation>
```

Voor alle tooling is het genoeg om een xs:documentation bij de complextype definities te hebben; het wordt afgeleid dat die documentatie ook bij het element `<vergadering>` hoort. Als we het zo aanpakken voldoen we beter aan single source of truth.

Anderzijds is het soms handig — of zelfs nodig — om documentatie op beide plekken te hebben. Je wilt nog steeds kunnen uitdrukken wat het verschil is tussen het element `<aanwezigeDeelnemer>` en `<persoonBuitenVergadering>`, ondanks dat ze alletwee `natuurlijkpersoonGegevens` gebruiken. Ook is het soms handig om kleine naunces aan te brengen — bijv. "Gegevens over een spreekfragment waarin _de_ deelnemer sprak" vs. "Gegevens over een spreekfragment waarin _een_ deelnemer sprak".

Ik denk uiteindelijk dat zo duidelijk mogelijke documentatie belangrijker is dan wat extra herhaling. Bovendien ziet het er vreemd uit om sommige elementen ongedocumenteerd te laten.