### PR TITLE
docs: herformuleer functie van element

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -674,7 +674,7 @@
         <xs:sequence>
             <xs:element name="omschrijving" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Omschrijving van iemands nevenfunctie.</xs:documentation>
+                     <xs:documentation>Informatie over de inhoud van iemands nevenfunctie, zoals de officiële functietitel of een korte beschrijving.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="naamOrganisatie" type="xs:string" minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
In het voorbeeldbestand zie je doorgaans iets dat meer lijkt op een titel dan een omschrijving, alhoewel de grens tussen die twee sowieso vaag is:

```xml
<omschrijving>Promovendus</omschrijving>
<omschrijving>Projectmanager Sociale Zaken en Werkgelegenheid</omschrijving>
<omschrijving>Voorzitter RozeLinks</omschrijving>
<omschrijving>Transitiemanager</omschrijving>
```

Ik vind mijn huidige formulering een beetje eh, maar ik wil wel graag verduidelijken dat bovenstaande voorbeelden momenteel een valide toepassing zijn van dit element.