### PR TITLE
enumeratie simpleTypes namen gegeven

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -182,17 +182,10 @@
                     <xs:documentation>Actuele link naar een online raadpleeglocatie waar de vergadering in zijn geheel wordt getoond, zoals de publicatieomgeving van een e-depot of raadsinformatiesysteem.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="status" minOccurs="0" maxOccurs="1">
+            <xs:element name="status" type="status" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>De status van de vergadering.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="status">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Gepland"/>
-                        <xs:enumeration value="Gehouden"/>
-                        <xs:enumeration value="Geannuleerd"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
             <xs:element name="geplandeVergaderdatum" type="xs:date" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
@@ -297,7 +290,7 @@
                 <xs:annotation>
                     <xs:documentation>Het geplande agendapunt volgnummer. Begint met een of meer cijfers, maar mag gevolgd worden door andere karakters.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="geplandVolgnummer">
+                <xs:simpleType>
                     <xs:restriction base="xs:string">
                         <xs:pattern value="\d+.*"/>
                     </xs:restriction>
@@ -307,7 +300,7 @@
                 <xs:annotation>
                     <xs:documentation>Het agendapunt volgnummer. Begint met een of meer cijfers, maar mag gevolgd worden door andere karakters.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="volgnummer">
+                <xs:simpleType>
                     <xs:restriction base="xs:string">
                         <xs:pattern value="\d+.*"/>
                     </xs:restriction>
@@ -489,29 +482,15 @@
                     <xs:documentation>Uniek identificatiekenmerk van de stemming.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="stemmingstype" minOccurs="0" maxOccurs="1">
+            <xs:element name="stemmingstype" type="stemmingstype" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>De wijze waarop gestemd is.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="stemmingstype">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Hoofdelijk"/>
-                        <xs:enumeration value="Regulier"/>
-                        <xs:enumeration value="Schriftelijk"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
-            <xs:element name="resultaatMondelingeStemming" minOccurs="0" maxOccurs="1">
+            <xs:element name="resultaatMondelingeStemming" type="resultaatMondelingeStemming" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Het resultaat van de mondelinge stemming.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="resultaatMondelingeStemming">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Voor"/>
-                        <xs:enumeration value="Tegen"/>
-                        <xs:enumeration value="Gelijk"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
             <xs:element name="resultaatStemmingOverPersonen" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
@@ -578,20 +557,10 @@
                     <xs:documentation>Een toezegging die bij het besluit gedaan is.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="besluitResultaat" minOccurs="1" maxOccurs="1">
+            <xs:element name="besluitResultaat" type="besluitResultaat" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Het resultaat van het besluit.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="besluitResultaat">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Unaniem aangenomen"/>
-                        <xs:enumeration value="Aangenomen"/>
-                        <xs:enumeration value="Geamendeerd aangenomen"/>
-                        <xs:enumeration value="Onder voorbehoud aangenomen"/>
-                        <xs:enumeration value="Verworpen"/>
-                        <xs:enumeration value="Aangehouden"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
         </xs:sequence>
     </xs:complexType>
@@ -687,18 +656,10 @@
                     <xs:documentation>Uniek identificatiekenmerk van de persoon.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="geslachtsaanduiding" minOccurs="0" maxOccurs="1">
+            <xs:element name="geslachtsaanduiding" type="geslachtsaanduiding" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Geslachtaanduiding van de persoon.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="geslachtsaanduiding">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Man"/>
-                        <xs:enumeration value="Vrouw"/>
-                        <xs:enumeration value="Anders"/>
-                        <xs:enumeration value="Onbekend"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
             <xs:element name="functie" type="begripGegevens" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
@@ -895,17 +856,10 @@
                     <xs:documentation>Uniek identificatiekenmerk van het stemresultaat per fractie.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="fractieStemresultaat" minOccurs="1" maxOccurs="1">
+            <xs:element name="fractieStemresultaat" type="fractieStemresultaat" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>Geeft aan hoe de fractie als geheel tegenover een stemming stond.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="fractieStemresultaat">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Aangenomen"/>
-                        <xs:enumeration value="Verworpen"/>
-                        <xs:enumeration value="Verdeeld"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
             <xs:element name="verwijzingStemming" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
@@ -987,18 +941,10 @@
                     <xs:documentation>Uniek identificatiekenmerk van de stem.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="keuzeStemming" minOccurs="1" maxOccurs="1">
+            <xs:element name="keuzeStemming" type="keuzeStemming" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>De keuze op de stemming.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType name="keuzeStemming">
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Voor"/>
-                        <xs:enumeration value="Tegen"/>
-                        <xs:enumeration value="Afwezig"/>
-                        <xs:enumeration value="Onthouden"/>
-                    </xs:restriction>
-                </xs:simpleType>
             </xs:element>
             <xs:element name="gegevenOpStemming" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
@@ -1024,4 +970,58 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
+    <xs:simpleType name="stemmingstype">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Hoofdelijk"/>
+            <xs:enumeration value="Regulier"/>
+            <xs:enumeration value="Schriftelijk"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="resultaatMondelingeStemming">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Voor"/>
+            <xs:enumeration value="Tegen"/>
+            <xs:enumeration value="Gelijk"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="besluitResultaat">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Unaniem aangenomen"/>
+            <xs:enumeration value="Aangenomen"/>
+            <xs:enumeration value="Geamendeerd aangenomen"/>
+            <xs:enumeration value="Onder voorbehoud aangenomen"/>
+            <xs:enumeration value="Verworpen"/>
+            <xs:enumeration value="Aangehouden"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="geslachtsaanduiding">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Man"/>
+            <xs:enumeration value="Vrouw"/>
+            <xs:enumeration value="Anders"/>
+            <xs:enumeration value="Onbekend"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="fractieStemresultaat">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Aangenomen"/>
+            <xs:enumeration value="Verworpen"/>
+            <xs:enumeration value="Verdeeld"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="keuzeStemming">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Voor"/>
+            <xs:enumeration value="Tegen"/>
+            <xs:enumeration value="Afwezig"/>
+            <xs:enumeration value="Onthouden"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="status">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Gepland"/>
+            <xs:enumeration value="Gehouden"/>
+            <xs:enumeration value="Geannuleerd"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -186,7 +186,7 @@
                 <xs:annotation>
                     <xs:documentation>De status van de vergadering.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="status">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Gepland"/>
                         <xs:enumeration value="Gehouden"/>
@@ -297,7 +297,7 @@
                 <xs:annotation>
                     <xs:documentation>Het geplande agendapunt volgnummer. Begint met een of meer cijfers, maar mag gevolgd worden door andere karakters.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="geplandVolgnummer">
                     <xs:restriction base="xs:string">
                         <xs:pattern value="\d+.*"/>
                     </xs:restriction>
@@ -307,7 +307,7 @@
                 <xs:annotation>
                     <xs:documentation>Het agendapunt volgnummer. Begint met een of meer cijfers, maar mag gevolgd worden door andere karakters.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="volgnummer">
                     <xs:restriction base="xs:string">
                         <xs:pattern value="\d+.*"/>
                     </xs:restriction>
@@ -493,7 +493,7 @@
                 <xs:annotation>
                     <xs:documentation>De wijze waarop gestemd is.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="stemmingstype">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Hoofdelijk"/>
                         <xs:enumeration value="Regulier"/>
@@ -505,7 +505,7 @@
                 <xs:annotation>
                     <xs:documentation>Het resultaat van de mondelinge stemming.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="resultaatMondelingeStemming">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Voor"/>
                         <xs:enumeration value="Tegen"/>
@@ -582,7 +582,7 @@
                 <xs:annotation>
                     <xs:documentation>Het resultaat van het besluit.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="besluitResultaat">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Unaniem aangenomen"/>
                         <xs:enumeration value="Aangenomen"/>
@@ -691,7 +691,7 @@
                 <xs:annotation>
                     <xs:documentation>Geslachtaanduiding van de persoon.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="geslachtsaanduiding">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Man"/>
                         <xs:enumeration value="Vrouw"/>
@@ -899,7 +899,7 @@
                 <xs:annotation>
                     <xs:documentation>Geeft aan hoe de fractie als geheel tegenover een stemming stond.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="fractieStemresultaat">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Aangenomen"/>
                         <xs:enumeration value="Verworpen"/>
@@ -991,7 +991,7 @@
                 <xs:annotation>
                     <xs:documentation>De keuze op de stemming.</xs:documentation>
                 </xs:annotation>
-                <xs:simpleType>
+                <xs:simpleType name="keuzeStemming">
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="Voor"/>
                         <xs:enumeration value="Tegen"/>


### PR DESCRIPTION
Uitwerking van #74 

Om deze door te voeren moest ik de enumeratie simpleTypes losknippen uit hun parent elementen en als eigen 'global' simpleTypes definiëren. Ze staan nu onderaan de XSD op een rijtje.