### PR TITLE
1.0.1 release

### DIFF
--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -48,7 +48,7 @@
                 </xs:element>
                 <xs:element name="persoonBuitenVergadering" type="natuurlijkPersoonGegevens" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
-                        <xs:documentation>Gegevens over een persoon die een relatie heeft met de vergadering, maar _niet_ zelf aanwezig was. Dit kan bijvoorbeeld een portefeuillehouder, indiender of afwezig raadslid zijn. Persoonsgegevens over aanwezigen komen onder `aanwezigeDeelnemer`.</xs:documentation>
+                        <xs:documentation>Gegevens over een persoon die een relatie heeft met de vergadering, maar _niet_ zelf aanwezig was. Dit kan bijvoorbeeld een portefeuillehouder, indiener of afwezig raadslid zijn. Persoonsgegevens over aanwezigen komen onder `aanwezigeDeelnemer`.</xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element name="aanwezigeDeelnemer" type="aanwezigeDeelnemerGegevens" minOccurs="0" maxOccurs="unbounded">

--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://ori-a.nl" targetNamespace="https://ori-a.nl" xmlns:ori-a="https://ori-a.nl" elementFormDefault="qualified" version="v1.0.0">
     <xs:element name="ORI-A">
+        <xs:annotation>
+            <xs:documentation>Het _root_-element. Bevat alle ORI-A gegevens.</xs:documentation>
+        </xs:annotation>
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="vergadering" type="vergaderingGegevens" minOccurs="1" maxOccurs="1">

--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -158,7 +158,7 @@
             </xs:element>
             <xs:element name="isRelatiefTot" type="informatieobjectGegevens" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over de mediabron waar deze tijdsaanduiding betrekking op heeft, zoals het identificatiekenmerk van een video-opname. Dit element is alleen nodig wanneer er meer dan een mediabron aan een vergadering is gerelateerd. Als dit element ontbreekt, moet worden verondersteld dat de tijdsaanduiding relatief is tot de mediabron die is vastgelegd onder het top-level element `vergadering`.</xs:documentation>
+                    <xs:documentation>Gegevens over de mediabron waar deze tijdsaanduiding betrekking op heeft, zoals het identificatiekenmerk van een video-opname. Dit element is alleen nodig wanneer er meer dan een mediabron aan een vergadering is gerelateerd. Als dit element ontbreekt, moet worden verondersteld dat de tijdsaanduiding relatief is tot de mediabron die is vastgelegd onder het top-level `&lt;vergadering&gt;`-element.</xs:documentation>
                 </xs:annotation>
             </xs:element>
         </xs:sequence>

--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -83,24 +83,24 @@
         <xs:annotation>
             <xs:documentation>Gegevens over een begrip, zoals de locatie van de begrippenlijst waar het begrip verklaard wordt.</xs:documentation>
         </xs:annotation>
-		<xs:sequence>
-			<xs:element name="begripLabel" type="xs:string" minOccurs="1" maxOccurs="1">
-				<xs:annotation>
-					<xs:documentation>Het label dat aan het begrip is toegekend in de begrippenlijst.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="begripCode" type="xs:string" minOccurs="0" maxOccurs="1">
-				<xs:annotation>
-					<xs:documentation>De code die aan het begrip is toegekend in de begrippenlijst.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="verwijzingBegrippenlijst" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
-				<xs:annotation>
-					<xs:documentation>Een verwijzing naar de begrippenlijst waarin het begrip beschreven wordt. Het ID van de begrippenlijst waarnaar verwezen wordt is meestal een URL, en de gewenste naam de titel van de begrippenlijst (bijvoorbeeld 'ORI-A vergaderstuktypes').</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
+        <xs:sequence>
+            <xs:element name="begripLabel" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Het label dat aan het begrip is toegekend in de begrippenlijst.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="begripCode" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>De code die aan het begrip is toegekend in de begrippenlijst.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="verwijzingBegrippenlijst" type="verwijzingGegevens" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Een verwijzing naar de begrippenlijst waarin het begrip beschreven wordt. Het ID van de begrippenlijst waarnaar verwezen wordt is meestal een URL, en de gewenste naam de titel van de begrippenlijst (bijvoorbeeld 'ORI-A vergaderstuktypes').</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:complexType name="informatieobjectGegevens">
         <xs:annotation>

--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://ori-a.nl" targetNamespace="https://ori-a.nl" xmlns:ori-a="https://ori-a.nl" elementFormDefault="qualified" version="v1.0.0">
-    <xs:element name="ORI-A">
+
+    <!-- root-element -->
+    <xs:element name="ORI-A" type="ORI-A">
+        <!-- Specificeer dat alle IDs in de XML-boom uniek moeten zijn -->
+        <xs:unique name="uniqueID">
+            <xs:selector xpath=".//ori-a:ID"/>
+            <xs:field xpath="."/>
+        </xs:unique>
+    </xs:element>
+
+    <!-- datatype van root-element -->
+    <xs:complexType name="ORI-A">
         <xs:annotation>
-            <xs:documentation>Het _root_-element. Bevat alle ORI-A gegevens.</xs:documentation>
+            <xs:documentation>Gegevens die onder het _root_-element `&lt;ORI-A&gt;` komen.</xs:documentation>
         </xs:annotation>
-        <xs:complexType>
             <xs:sequence>
                 <xs:element name="vergadering" type="vergaderingGegevens" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
@@ -48,12 +58,6 @@
                 </xs:element>
             </xs:sequence>
         </xs:complexType>
-        <!-- Specificeer dat alle IDs in de XML-boom uniek moeten zijn -->
-        <xs:unique name="uniqueID">
-            <xs:selector xpath=".//ori-a:ID"/>
-            <xs:field xpath="."/>
-        </xs:unique>
-    </xs:element>
 
     <!-- # Algemene datatypes -->
 

--- a/ORI-A.xsd
+++ b/ORI-A.xsd
@@ -994,7 +994,7 @@
             </xs:element>
             <xs:element name="neemtDeelAanStemming" type="stemGegevens" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
-                    <xs:documentation>Gegevens over een stem die de deelnemer heeft uitbracht, zoals de stemkeuze en de stemming waarop deze keuze betrekking heeft.</xs:documentation>
+                    <xs:documentation>Gegevens over een stem die de deelnemer heeft uitgebracht, zoals de stemkeuze en de stemming waarop deze keuze betrekking heeft.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="spreektTijdensSpreekfragment" type="spreekfragmentGegevens" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
Een kleine release, die vooral gericht is op documentatie typos.  Er staan nu twee documentatie verbeteringen in. Ik kan me herinneren dat ik ooit nog een ander vond, maar die kan ik niet meer terug vinden. Als je 'm wel kan vinden geef ik je de OD kwaliteitsaward.  

Andere verandering is dat `ORI-A` nu niet alleen de naam van het root-element is, maar ook de naam van het bijbehorende complextype. Op de website deden we al of dit zo was (zie https://ori-a.nl/xml-schema#ori-a en de intro tekst daarboven). Deze verandering helpt ook met het genereren van documentatie, trouwens.  

Sluit https://github.com/Regionaal-Archief-Rivierenland/ORI-A-XSD/issues/82. 

(**please nog niet mergen**)